### PR TITLE
Fixes an issue where if there's any promise already resolved or rejected...

### DIFF
--- a/Deferred/KSPromise.m
+++ b/Deferred/KSPromise.m
@@ -73,8 +73,8 @@
 + (KSPromise *)when:(NSArray *)promises {
     KSPromise *promise = [[KSPromise alloc] init];
     promise.parentPromises = [NSMutableArray array];
+    [promise.parentPromises addObjectsFromArray:promises];
     for (KSPromise *joinedPromise in promises) {
-        [promise.parentPromises addObject:joinedPromise];
         [joinedPromise then:^id(id value) {
             [promise joinedPromiseFulfilled:joinedPromise];
             return value;


### PR DESCRIPTION
... at the time of join, joined promise resolves instantly without waiting for all other promises to resolve.
# 

We, at IMVU, found out that there're some cases where joining promises don't wait till all get resolved/rejected.
And it was due to the fact that when some promises have been already resolved before joining, it instantly resolves the joined promise.

So I committed a fix with updated Specs.
Please take a look.

Thanks.
- Todd
