### PR TITLE
Expose fulfilled, rejected, cancelled fields on KSPromise

### DIFF
--- a/Deferred/KSPromise.h
+++ b/Deferred/KSPromise.h
@@ -9,6 +9,9 @@ typedef void(^deferredCallback)(KSPromise *p);
 @interface KSPromise : NSObject
 @property (strong, nonatomic, readonly) id value;
 @property (strong, nonatomic, readonly) NSError *error;
+@property (assign, nonatomic, readonly) BOOL fulfilled;
+@property (assign, nonatomic, readonly) BOOL rejected;
+@property (assign, nonatomic, readonly) BOOL cancelled;
 
 
 + (KSPromise *)when:(NSArray *)promises;

--- a/Specs/KSDeferredSpec.mm
+++ b/Specs/KSDeferredSpec.mm
@@ -94,6 +94,10 @@ describe(@"KSDeferred", ^{
                     });
                     
                 });
+
+                it(@"should be marked as fulfilled", ^{
+                    joinedPromise.fulfilled should be_truthy;
+                });
             });
 
             describe(@"when the first promise is rejected", ^{
@@ -104,6 +108,10 @@ describe(@"KSDeferred", ^{
                 it(@"should not reject the joined promise", ^{
                     fulfilled should_not be_truthy;
                     rejected should_not be_truthy;
+                });
+
+                it(@"should be marked as rejected", ^{
+                    joinedPromise.rejected should be_truthy;
                 });
             });
         });


### PR DESCRIPTION
We needed to expose these to clean up some tests in our project.
