### PR TITLE
Fix incorrect tests in the spec for when:

### DIFF
--- a/Specs/KSDeferredSpec.mm
+++ b/Specs/KSDeferredSpec.mm
@@ -96,7 +96,7 @@ describe(@"KSDeferred", ^{
                 });
 
                 it(@"should be marked as fulfilled", ^{
-                    joinedPromise.fulfilled should be_truthy;
+                    promise.fulfilled should be_truthy;
                 });
             });
 
@@ -111,7 +111,7 @@ describe(@"KSDeferred", ^{
                 });
 
                 it(@"should be marked as rejected", ^{
-                    joinedPromise.rejected should be_truthy;
+                    promise2.rejected should be_truthy;
                 });
             });
         });


### PR DESCRIPTION
These seem to have been introduced and failing starting at e0b7e34fff85a83e52c9e75120192cfc21e1dc19
