### PR TITLE
KSNetworkClient adds the response data to the userInfo of the error it rejects with on failed request

### DIFF
--- a/Deferred/KSNetworkClient.h
+++ b/Deferred/KSNetworkClient.h
@@ -9,6 +9,8 @@
 + (KSNetworkResponse *)networkResponseWithURLResponse:(NSURLResponse *)response data:(NSData *)data;
 @end
 
+FOUNDATION_EXPORT NSString *const kKSNetworkClientErrorData;
+
 @interface KSNetworkClient : NSObject
 - (KSPromise *)sendAsynchronousRequest:(NSURLRequest *)request queue:(NSOperationQueue *)queue;
 @end

--- a/Deferred/KSNetworkClient.m
+++ b/Deferred/KSNetworkClient.m
@@ -6,6 +6,8 @@
 @property (strong, nonatomic, readwrite) NSData *data;
 @end
 
+NSString *const kKSNetworkClientErrorData = @"kKSNetworkClientErrorData";
+
 @implementation KSNetworkResponse
 + (KSNetworkResponse *)networkResponseWithURLResponse:(NSURLResponse *)response data:(NSData *)data {
     KSNetworkResponse *networkResponse = [[KSNetworkResponse alloc] init];
@@ -19,16 +21,23 @@
 
 - (KSPromise *)sendAsynchronousRequest:(NSURLRequest *)request queue:(NSOperationQueue *)queue {
     KSDeferred *deferred = [KSDeferred defer];
-    [NSURLConnection sendAsynchronousRequest:request
-                                       queue:queue
-                           completionHandler:^(NSURLResponse *response, NSData *data, NSError *error) {
-        if (error) {
-            [deferred rejectWithError:error];
-        } else {
-            [deferred resolveWithValue:[KSNetworkResponse networkResponseWithURLResponse:response
-                                                                                    data:data]];
-        }
-    }];
+    [NSURLConnection
+     sendAsynchronousRequest:request
+     queue:queue
+     completionHandler:^(NSURLResponse *response, NSData *data, NSError *error) {
+         if (data && error) {
+             NSMutableDictionary *userInfo = [@{kKSNetworkClientErrorData: data} mutableCopy];
+             [userInfo addEntriesFromDictionary:error.userInfo];
+             error = [NSError errorWithDomain:error.domain code:error.code userInfo:userInfo];
+         }
+
+         if (error) {
+             [deferred rejectWithError:error];
+         } else {
+             [deferred resolveWithValue:[KSNetworkResponse networkResponseWithURLResponse:response data:data]];
+         }
+     }];
+
     return deferred.promise;
 }
 

--- a/Specs/KSNetworkClientSpec.mm
+++ b/Specs/KSNetworkClientSpec.mm
@@ -1,83 +1,78 @@
 #import <Cedar/SpecHelper.h>
 #import "KSNetworkClient.h"
 #import "KSPromise.h"
+#import <objc/runtime.h>
 
 using namespace Cedar::Matchers;
 using namespace Cedar::Doubles;
-
-@interface KSNetworkClientSpecURLProtocol : NSURLProtocol
-@end
-
-@implementation KSNetworkClientSpecURLProtocol
-
-+ (BOOL)canInitWithRequest:(NSURLRequest *)request {
-    return [@[@"pass", @"fail"] containsObject:request.URL.scheme];
-}
-
-+ (NSURLRequest *)canonicalRequestForRequest:(NSURLRequest *)request {
-    return request;
-}
-
-+ (BOOL)requestIsCacheEquivalent:(NSURLRequest *)a toRequest:(NSURLRequest *)b {
-    return NO;
-}
-
-- (void)startLoading {
-    if ([self.request.URL.scheme isEqualToString:@"pass"]) {
-        NSURLResponse *response = [[NSURLResponse alloc] init];
-        [self.client URLProtocol:self didReceiveResponse:response cacheStoragePolicy:NSURLCacheStorageNotAllowed];
-        [self.client URLProtocol:self didLoadData:[@"pass" dataUsingEncoding:NSUTF8StringEncoding]];
-        [self.client URLProtocolDidFinishLoading:self];
-    } else {
-        [self.client URLProtocol:self didFailWithError:[NSError errorWithDomain:@"fail" code:1 userInfo:nil]];
-    }
-}
-
-- (void)stopLoading {}
-@end
 
 
 SPEC_BEGIN(KSNetworkClientSpec)
 
 describe(@"KSNetworkClient", ^{
     __block KSNetworkClient *client;
-    __block NSOperationQueue *queue;
+    __block KSPromise *promise;
+    __block void(^asyncRequestCallback)(NSURLResponse *, NSData *, NSError *);
 
     beforeEach(^{
         client = [[KSNetworkClient alloc] init];
-        queue = [[NSOperationQueue alloc] init];
-        [NSURLProtocol registerClass:[KSNetworkClientSpecURLProtocol class]];
+
+        Class metaClass = objc_getMetaClass(NSStringFromClass([NSURLConnection class]).UTF8String);
+
+        IMP fakeAsyncIMP = imp_implementationWithBlock(^(id me, NSURLRequest *r, NSOperationQueue *q, void(^callback)(NSURLResponse *, NSData *, NSError *)){
+            asyncRequestCallback = [callback copy];
+        });
+
+        Method originalMethod = class_getClassMethod(metaClass, @selector(sendAsynchronousRequest:queue:completionHandler:));
+        method_setImplementation(originalMethod, fakeAsyncIMP);
+
+        NSURLRequest *request = [NSURLRequest new];
+        promise = [client sendAsynchronousRequest:request queue:[NSOperationQueue mainQueue]];
     });
 
     it(@"should resolve the promise on success", ^{
-        NSURLRequest *request = [[NSURLRequest alloc] initWithURL:[NSURL URLWithString:@"pass://foo"]];
-        KSPromise *promise = [client sendAsynchronousRequest:request queue:queue];
-        dispatch_semaphore_t sema = dispatch_semaphore_create(0);
-        [promise then:^id(id value) {
-            dispatch_semaphore_signal(sema);
-            return value;
-        } error:^id(NSError *error) {
-            dispatch_semaphore_signal(sema);
-            return error;
-        }];
-        dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
+        asyncRequestCallback([NSURLResponse new], [@"pass" dataUsingEncoding:NSUTF8StringEncoding], nil);
+
         NSString *value = [[NSString alloc] initWithData:[promise.value data] encoding:NSUTF8StringEncoding];
         value should equal(@"pass");
     });
 
-    it(@"should reject the promise on error", ^{
-        NSURLRequest *request = [[NSURLRequest alloc] initWithURL:[NSURL URLWithString:@"fail://bar"]];
-        KSPromise *promise = [client sendAsynchronousRequest:request queue:queue];
-        dispatch_semaphore_t sema = dispatch_semaphore_create(0);
-        [promise then:^id(id value) {
-            dispatch_semaphore_signal(sema);
-            return value;
-        } error:^id(NSError *error) {
-            dispatch_semaphore_signal(sema);
-            return error;
-        }];
-        dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
-        promise.error.domain should equal(@"fail");
+    describe(@"with an error", ^{
+        context(@"when there is an error and no data", ^{
+            it(@"rejects with the unmodified error", ^{
+                NSError *error = [NSError errorWithDomain:@"Spec" code:0 userInfo:@{}];
+                asyncRequestCallback([NSURLResponse new], nil, error);
+
+                promise.error should equal(error);
+            });
+        });
+
+        context(@"when there is an error that has data", ^{
+            it(@"rejects with an error that has a kKSNetworkClientErrorData entry in the userInfo", ^{
+                NSError *error = [NSError errorWithDomain:@"Spec" code:0 userInfo:@{@"otherKey": @"otherValue"}];
+                NSData *data = [@"fail" dataUsingEncoding:NSUTF8StringEncoding];
+                asyncRequestCallback([NSURLResponse new], data, error);
+
+                promise.error.domain should equal(error.domain);
+                promise.error.code should equal(error.code);
+
+                promise.error.userInfo[kKSNetworkClientErrorData] should equal(data);
+                promise.error.userInfo[@"otherKey"] should equal(@"otherValue");
+            });
+        });
+
+        context(@"when there is an error that has data and nil userInfo", ^{
+            it(@"rejects with an error with a new userInfo dictionary containing kKSNetworkClientErrorData", ^{
+                NSError *error = [NSError errorWithDomain:@"Spec" code:0 userInfo:nil];
+                NSData *data = [@"fail" dataUsingEncoding:NSUTF8StringEncoding];
+                asyncRequestCallback([NSURLResponse new], data, error);
+
+                promise.error.domain should equal(error.domain);
+                promise.error.code should equal(error.code);
+
+                promise.error.userInfo[kKSNetworkClientErrorData] should equal(data);
+            });
+        });
     });
 });
 


### PR DESCRIPTION
There is unexpected behavior for [NSURLConnection -sendAsynchronousRequest:queue:completionHandler:] where particular 4xx responses (e.g. 401) are handled as errors but response data is still available.  Usually, 4xx responses have response data but no error so that the promise returned by sendAsynchronousRequest has access to the response data on resolution.  This pull request adds the response data as a field on the userInfo of NSURLConnection errors, making the response data accessible on rejection.