### PR TITLE
Add values to errors for joined promises

### DIFF
--- a/Deferred/KSPromise.h
+++ b/Deferred/KSPromise.h
@@ -9,6 +9,8 @@ typedef id(^promiseErrorCallback)(NSError *error);
 typedef void(^deferredCallback)(KSPromise *p);
 
 FOUNDATION_EXPORT NSString *const KSPromiseWhenErrorDomain;
+FOUNDATION_EXPORT NSString *const KSPromiseWhenErrorErrorsKey;
+FOUNDATION_EXPORT NSString *const KSPromiseWhenErrorValuesKey;
 
 @interface KSPromise : NSObject<KSCancellable>
 @property (strong, nonatomic, readonly) id value;

--- a/Deferred/KSPromise.h
+++ b/Deferred/KSPromise.h
@@ -8,6 +8,8 @@ typedef id(^promiseValueCallback)(id value);
 typedef id(^promiseErrorCallback)(NSError *error);
 typedef void(^deferredCallback)(KSPromise *p);
 
+FOUNDATION_EXPORT NSString *const KSPromiseWhenErrorDomain;
+
 @interface KSPromise : NSObject<KSCancellable>
 @property (strong, nonatomic, readonly) id value;
 @property (strong, nonatomic, readonly) NSError *error;

--- a/Deferred/KSPromise.m
+++ b/Deferred/KSPromise.m
@@ -31,6 +31,8 @@
 
 
 NSString *const KSPromiseWhenErrorDomain = @"KSPromiseJoinError";
+NSString *const KSPromiseWhenErrorErrorsKey = @"KSPromiseWhenErrorErrorsKey";
+NSString *const KSPromiseWhenErrorValuesKey = @"KSPromiseWhenErrorValuesKey";
 
 
 @implementation KSPromiseCallbacks
@@ -281,9 +283,11 @@ NSString *const KSPromiseWhenErrorDomain = @"KSPromiseJoinError";
     }
     if (fulfilled) {
         if (errors.count > 0) {
+            NSDictionary *userInfo = @{KSPromiseWhenErrorErrorsKey: errors,
+                                       KSPromiseWhenErrorValuesKey: values};
             NSError *whenError = [NSError errorWithDomain:KSPromiseWhenErrorDomain
                                                      code:1
-                                                 userInfo:@{@"errors": errors}];
+                                                 userInfo:userInfo];
             [self rejectWithError:whenError];
         } else {
             [self resolveWithValue:values];

--- a/Deferred/KSPromise.m
+++ b/Deferred/KSPromise.m
@@ -15,7 +15,9 @@
 #   define KS_DISPATCH_RELEASE(q)
 #endif
 
+
 @interface KSPromiseCallbacks : NSObject
+
 @property (copy, nonatomic) promiseValueCallback fulfilledCallback;
 @property (copy, nonatomic) promiseErrorCallback errorCallback;
 
@@ -24,7 +26,12 @@
 @property (copy, nonatomic) deferredCallback deprecatedCompleteCallback;
 
 @property (strong, nonatomic) KSPromise *childPromise;
+
 @end
+
+
+NSString *const KSPromiseWhenErrorDomain = @"KSPromiseJoinError";
+
 
 @implementation KSPromiseCallbacks
 
@@ -274,7 +281,10 @@
     }
     if (fulfilled) {
         if (errors.count > 0) {
-            [self rejectWithError:[NSError errorWithDomain:@"KSPromiseJoinError" code:1 userInfo:[NSDictionary dictionaryWithObject:errors forKey:@"errors"]]];
+            NSError *whenError = [NSError errorWithDomain:KSPromiseWhenErrorDomain
+                                                     code:1
+                                                 userInfo:@{@"errors": errors}];
+            [self rejectWithError:whenError];
         } else {
             [self resolveWithValue:values];
         }

--- a/Specs/KSDeferredSpec.mm
+++ b/Specs/KSDeferredSpec.mm
@@ -94,7 +94,7 @@ describe(@"KSDeferred", ^{
                     });
                     
                     it(@"should be able to read the resolved values of the joined promises", ^{
-                        joinedPromise.error.domain should equal(@"KSPromiseJoinError");
+                        joinedPromise.error.domain should equal(KSPromiseWhenErrorDomain);
                         NSArray *errors = [joinedPromise.error.userInfo objectForKey:@"errors"];
                         errors.count should equal(1);
                         [[errors lastObject] domain] should equal(@"MyError");

--- a/Specs/KSDeferredSpec.mm
+++ b/Specs/KSDeferredSpec.mm
@@ -49,7 +49,7 @@ describe(@"KSDeferred", ^{
                 }];
             });
 
-            describe(@"when the first promise is resolved", ^{
+            context(@"when the first promise is resolved", ^{
                 beforeEach(^{
                     [deferred resolveWithValue:@"SUCCESS1"];
                 });
@@ -59,7 +59,7 @@ describe(@"KSDeferred", ^{
                     rejected should_not be_truthy;
                 });
                 
-                describe(@"when both promises are resolved", ^{
+                context(@"when both promises are resolved", ^{
                     beforeEach(^{
                         [deferred2 resolveWithValue:@"SUCCESS2"];
                     });
@@ -74,7 +74,7 @@ describe(@"KSDeferred", ^{
                     });
                 });
 
-                describe(@"when both promises are resolved, one without a value", ^{
+                context(@"when both promises are resolved, one without a value", ^{
                     beforeEach(^{
                         [deferred2 resolveWithValue:nil];
                     });
@@ -84,7 +84,7 @@ describe(@"KSDeferred", ^{
                     });
                 });
 
-                describe(@"when a promise is rejected and all joined promises have been fulfilled", ^{
+                context(@"when a promise is rejected and all joined promises have been fulfilled", ^{
                     beforeEach(^{
                         [deferred2 rejectWithError:[NSError errorWithDomain:@"MyError" code:123 userInfo:nil]];
                     });
@@ -101,7 +101,7 @@ describe(@"KSDeferred", ^{
                     });
                 });
 
-              describe(@"when a promise is rejected without an error and all joined promises have been fulfilled", ^{
+              context(@"when a promise is rejected without an error and all joined promises have been fulfilled", ^{
                     beforeEach(^{
                         [deferred2 rejectWithError:nil];
                     });
@@ -117,7 +117,7 @@ describe(@"KSDeferred", ^{
                 });
             });
 
-            describe(@"when the first promise is rejected", ^{
+            context(@"when the first promise is rejected", ^{
                 beforeEach(^{
                     [deferred2 rejectWithError:[NSError errorWithDomain:@"MyError" code:123 userInfo:nil]];
                 });
@@ -133,7 +133,7 @@ describe(@"KSDeferred", ^{
             });
         });
 
-        describe(@"when the first promise is resolved before joined", ^{
+        context(@"when the first promise is resolved before joined", ^{
             beforeEach(^{
                 [deferred resolveWithValue:@"SUCCESS1"];
                 joinedPromise = [KSPromise when:[NSArray arrayWithObjects:promise, promise2, nil]];
@@ -155,7 +155,7 @@ describe(@"KSDeferred", ^{
             });
         });
         
-        describe(@"when the first promise is rejected before joined", ^{
+        context(@"when the first promise is rejected before joined", ^{
             beforeEach(^{
                 [deferred rejectWithError:[NSError errorWithDomain:@"MyError" code:123 userInfo:nil]];
                 joinedPromise = [KSPromise when:[NSArray arrayWithObjects:promise, promise2, nil]];

--- a/Specs/KSDeferredSpec.mm
+++ b/Specs/KSDeferredSpec.mm
@@ -93,11 +93,18 @@ describe(@"KSDeferred", ^{
                         rejected should be_truthy;
                     });
                     
-                    it(@"should be able to read the resolved values of the joined promises", ^{
+                    it(@"should be able to read the rejected errors of the joined promises", ^{
                         joinedPromise.error.domain should equal(KSPromiseWhenErrorDomain);
-                        NSArray *errors = [joinedPromise.error.userInfo objectForKey:@"errors"];
+                        NSArray *errors = [joinedPromise.error.userInfo objectForKey:KSPromiseWhenErrorErrorsKey];
                         errors.count should equal(1);
                         [[errors lastObject] domain] should equal(@"MyError");
+                    });
+
+                    it(@"should be able to read the resolved values of the joined promises", ^{
+                        joinedPromise.error.domain should equal(KSPromiseWhenErrorDomain);
+                        NSArray *values = [joinedPromise.error.userInfo objectForKey:KSPromiseWhenErrorValuesKey];
+                        values.count should equal(1);
+                        values.lastObject should equal(@"SUCCESS1");
                     });
                 });
 
@@ -107,7 +114,7 @@ describe(@"KSDeferred", ^{
                     });
 
                     it(@"should insert a null object into the joined promises error list", ^{
-                        NSArray *errors = joinedPromise.error.userInfo[@"errors"];
+                        NSArray *errors = joinedPromise.error.userInfo[KSPromiseWhenErrorErrorsKey];
                         [errors lastObject] should equal([NSNull null]);
                     });
                 });


### PR DESCRIPTION
The promise returned from `when:` is rejected if even a single input promise is rejected.  This pull request ensures that the values of all resolved input promises are still available in this error case.  The successfully resolved values have been exposed via a string constant alongside the errors in the `userInfo` dictionary of the returned promise's NSError instance.