### PR TITLE
Fix excessive resolution/rejection bug in [KSPromise +when:]

### DIFF
--- a/Deferred/KSPromise.m
+++ b/Deferred/KSPromise.m
@@ -268,6 +268,10 @@ NSString *const KSPromiseWhenErrorValuesKey = @"KSPromiseWhenErrorValuesKey";
 
 #pragma mark - Private methods
 - (void)joinedPromiseFulfilled:(KSPromise *)promise {
+    if ([self completed]) {
+        return;
+    }
+    
     BOOL fulfilled = YES;
     NSMutableArray *errors = [NSMutableArray array];
     NSMutableArray *values = [NSMutableArray array];


### PR DESCRIPTION
If [KSPromise +when:] is constructed from an array of already resolved/rejected
promises, the joined promise will be resolved/rejected once for each promise