### PR TITLE
Add public headers to KSDeferred.h, turn on werror for the ios specs

### DIFF
--- a/Deferred.xcodeproj/project.pbxproj
+++ b/Deferred.xcodeproj/project.pbxproj
@@ -1030,6 +1030,7 @@
 					"DEBUG=1",
 					"$(inherited)",
 				);
+				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = DeferredSpecs/Info.plist;
@@ -1064,6 +1065,7 @@
 					"$(PROJECT_DIR)/DeferredSpecs/Frameworks",
 				);
 				GCC_PREFIX_HEADER = "$(SRCROOT)/Specs/Specs-Prefix.pch";
+				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = DeferredSpecs/Info.plist;

--- a/Deferred/KSDeferred.h
+++ b/Deferred/KSDeferred.h
@@ -1,6 +1,8 @@
 #import "KSPromise.h"
 #import "KSCancellable.h"
-
+#import "KSNetworkClient.h"
+#import "KSURLConnectionClient.h"
+#import "KSURLSessionClient.h"
 
 @interface KSDeferred : NSObject
 


### PR DESCRIPTION
Basically, if you use this as a dynamic framework (e.g. carthage), and have werror enabled
Then the compiler will error (generate a warning, actually) because it can't find headers
which should be publicly available in the main public header (e.g. KSDeferred.h).

This is also not something the tests will catch on, likely because the framework is successfully built
and then the test bundle is injected into the framework.

Maybe if we were using a test suite for this, then it might catch that?