### PR TITLE
Declare that KSDeferred can be used in app extensions.

### DIFF
--- a/Deferred.xcodeproj/project.pbxproj
+++ b/Deferred.xcodeproj/project.pbxproj
@@ -819,6 +819,7 @@
 		AE48647D1B0668A3005DB302 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -853,6 +854,7 @@
 		AE48647E1B0668A3005DB302 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;


### PR DESCRIPTION
Without this flag, having an app extension depend on KSDeferred causes warnings. The only possible downside is you cannot depend on a few pieces of UIKit that are not allowed to be used in app extensions. The only example I know of is `UIApplication`.