### PR TITLE
Add nullability annotations.

### DIFF
--- a/Deferred.xcodeproj/project.pbxproj
+++ b/Deferred.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		34244A271B4BA59C008A0DF0 /* KSNullabilityCompat.h in Headers */ = {isa = PBXBuildFile; fileRef = 34244A261B4BA559008A0DF0 /* KSNullabilityCompat.h */; };
+		34244A281B4BA59C008A0DF0 /* KSNullabilityCompat.h in Headers */ = {isa = PBXBuildFile; fileRef = 34244A261B4BA559008A0DF0 /* KSNullabilityCompat.h */; };
+		34244A291B4BA59D008A0DF0 /* KSNullabilityCompat.h in Headers */ = {isa = PBXBuildFile; fileRef = 34244A261B4BA559008A0DF0 /* KSNullabilityCompat.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		34244A2A1B4BA59D008A0DF0 /* KSNullabilityCompat.h in Headers */ = {isa = PBXBuildFile; fileRef = 34244A261B4BA559008A0DF0 /* KSNullabilityCompat.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AE3C6E4D19A3533B004BECE4 /* KSURLConnectionClient.h in Headers */ = {isa = PBXBuildFile; fileRef = AE3C6E4B19A3533B004BECE4 /* KSURLConnectionClient.h */; };
 		AE3C6E4E19A3533B004BECE4 /* KSURLConnectionClient.m in Sources */ = {isa = PBXBuildFile; fileRef = AE3C6E4C19A3533B004BECE4 /* KSURLConnectionClient.m */; };
 		AE3C6E6019A354CB004BECE4 /* KSURLConnectionClient.m in Sources */ = {isa = PBXBuildFile; fileRef = AE3C6E4C19A3533B004BECE4 /* KSURLConnectionClient.m */; };
@@ -100,6 +104,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		34244A261B4BA559008A0DF0 /* KSNullabilityCompat.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = KSNullabilityCompat.h; sourceTree = "<group>"; };
 		AE3C6E4B19A3533B004BECE4 /* KSURLConnectionClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KSURLConnectionClient.h; sourceTree = "<group>"; };
 		AE3C6E4C19A3533B004BECE4 /* KSURLConnectionClient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KSURLConnectionClient.m; sourceTree = "<group>"; };
 		AE3C6E6119A354E5004BECE4 /* KSURLSessionClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KSURLSessionClient.h; sourceTree = "<group>"; };
@@ -353,6 +358,7 @@
 				AE3C6E4C19A3533B004BECE4 /* KSURLConnectionClient.m */,
 				AE3C6E6119A354E5004BECE4 /* KSURLSessionClient.h */,
 				AE3C6E6219A354E5004BECE4 /* KSURLSessionClient.m */,
+				34244A261B4BA559008A0DF0 /* KSNullabilityCompat.h */,
 			);
 			path = Deferred;
 			sourceTree = "<group>";
@@ -425,6 +431,7 @@
 			files = (
 				AE4864881B0668CB005DB302 /* KSCancellable.h in Headers */,
 				AE4864891B0668CB005DB302 /* KSDeferred.h in Headers */,
+				34244A291B4BA59D008A0DF0 /* KSNullabilityCompat.h in Headers */,
 				AE48648A1B0668CB005DB302 /* KSPromise.h in Headers */,
 				AE48648B1B0668CB005DB302 /* KSNetworkClient.h in Headers */,
 				AE48648C1B0668CB005DB302 /* KSURLConnectionClient.h in Headers */,
@@ -438,6 +445,7 @@
 			files = (
 				AE4864B11B066A6E005DB302 /* KSCancellable.h in Headers */,
 				AE4864B21B066A6E005DB302 /* KSDeferred.h in Headers */,
+				34244A2A1B4BA59D008A0DF0 /* KSNullabilityCompat.h in Headers */,
 				AE4864B31B066A6E005DB302 /* KSPromise.h in Headers */,
 				AE4864B41B066A6E005DB302 /* KSNetworkClient.h in Headers */,
 				AE4864B51B066A6E005DB302 /* KSURLConnectionClient.h in Headers */,
@@ -451,6 +459,7 @@
 			files = (
 				E15F47471570786900080763 /* KSDeferred.h in Headers */,
 				AE3C6E4D19A3533B004BECE4 /* KSURLConnectionClient.h in Headers */,
+				34244A271B4BA59C008A0DF0 /* KSNullabilityCompat.h in Headers */,
 				AE3C6E6F19A356CA004BECE4 /* KSNetworkClientSpecURLProtocol.h in Headers */,
 				AE3C6E6319A354E5004BECE4 /* KSURLSessionClient.h in Headers */,
 				E1E5C51516CAE6F000C1385F /* KSPromise.h in Headers */,
@@ -464,6 +473,7 @@
 			files = (
 				E15F47481570786900080763 /* KSDeferred.h in Headers */,
 				E1E5C51616CAE6F000C1385F /* KSPromise.h in Headers */,
+				34244A281B4BA59C008A0DF0 /* KSNullabilityCompat.h in Headers */,
 				AE3C6E6419A354E5004BECE4 /* KSURLSessionClient.h in Headers */,
 				E10B702816F11AF800957DA4 /* KSNetworkClient.h in Headers */,
 				AE3C6E7019A356CA004BECE4 /* KSNetworkClientSpecURLProtocol.h in Headers */,

--- a/Deferred/KSDeferred.h
+++ b/Deferred/KSDeferred.h
@@ -3,6 +3,9 @@
 #import "KSNetworkClient.h"
 #import "KSURLConnectionClient.h"
 #import "KSURLSessionClient.h"
+#import "KSNullabilityCompat.h"
+
+NS_ASSUME_NONNULL_BEGIN
 
 @interface KSDeferred : NSObject
 
@@ -10,8 +13,10 @@
 
 + (instancetype)defer;
 
-- (void)resolveWithValue:(id)value;
-- (void)rejectWithError:(NSError *)error;
+- (void)resolveWithValue:(nullable id)value;
+- (void)rejectWithError:(nullable NSError *)error;
 - (void)whenCancelled:(void (^)(void))cancelledBlock;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Deferred/KSNetworkClient.h
+++ b/Deferred/KSNetworkClient.h
@@ -1,6 +1,9 @@
 #import <Foundation/Foundation.h>
+#import "KSNullabilityCompat.h"
 
 @class KSPromise;
+
+NS_ASSUME_NONNULL_BEGIN
 
 @interface KSNetworkResponse : NSObject
 @property (strong, nonatomic, readonly) NSURLResponse *response;
@@ -19,3 +22,4 @@
 @interface KSNetworkClient : NSObject <KSNetworkClient>
 @end
 
+NS_ASSUME_NONNULL_END

--- a/Deferred/KSNullabilityCompat.h
+++ b/Deferred/KSNullabilityCompat.h
@@ -1,0 +1,16 @@
+
+#if !__has_feature(nullability)
+#ifndef NS_ASSUME_NONNULL_BEGIN
+
+#define NS_ASSUME_NONNULL_BEGIN
+#define NS_ASSUME_NONNULL_END
+#define nullable
+#define nonnull
+#define null_unspecified
+#define null_resettable
+#define __nullable
+#define __nonnull
+#define __null_unspecified
+
+#endif
+#endif

--- a/Deferred/KSPromise.h
+++ b/Deferred/KSPromise.h
@@ -1,11 +1,13 @@
 #import <Foundation/Foundation.h>
 #import "KSCancellable.h"
-
+#import "KSNullabilityCompat.h"
 
 @class KSPromise;
 
-typedef id(^promiseValueCallback)(id value);
-typedef id(^promiseErrorCallback)(NSError *error);
+NS_ASSUME_NONNULL_BEGIN
+
+typedef __nonnull id(^promiseValueCallback)(id value);
+typedef __nonnull id(^promiseErrorCallback)(NSError *error);
 typedef void(^deferredCallback)(KSPromise *p);
 
 FOUNDATION_EXPORT NSString *const KSPromiseWhenErrorDomain;
@@ -13,17 +15,17 @@ FOUNDATION_EXPORT NSString *const KSPromiseWhenErrorErrorsKey;
 FOUNDATION_EXPORT NSString *const KSPromiseWhenErrorValuesKey;
 
 @interface KSPromise : NSObject<KSCancellable>
-@property (strong, nonatomic, readonly) id value;
-@property (strong, nonatomic, readonly) NSError *error;
+@property (strong, nonatomic, readonly, nullable) id value;
+@property (strong, nonatomic, readonly, nullable) NSError *error;
 @property (assign, nonatomic, readonly) BOOL fulfilled;
 @property (assign, nonatomic, readonly) BOOL rejected;
 @property (assign, nonatomic, readonly) BOOL cancelled;
 
 + (KSPromise *)when:(NSArray *)promises;
-- (KSPromise *)then:(promiseValueCallback)fulfilledCallback error:(promiseErrorCallback)errorCallback;
+- (KSPromise *)then:(nullable promiseValueCallback)fulfilledCallback error:(nullable promiseErrorCallback)errorCallback;
 
 - (id)waitForValue;
-- (id)waitForValueWithTimeout:(NSTimeInterval)timeout;
+- (nullable id)waitForValueWithTimeout:(NSTimeInterval)timeout;
 
 - (void)addCancellable:(id<KSCancellable>)cancellable;
 
@@ -34,3 +36,5 @@ FOUNDATION_EXPORT NSString *const KSPromiseWhenErrorValuesKey;
 - (void)whenFulfilled:(deferredCallback)complete DEPRECATED_ATTRIBUTE;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Deferred/KSURLConnectionClient.h
+++ b/Deferred/KSURLConnectionClient.h
@@ -1,7 +1,11 @@
 #import "KSNetworkClient.h"
+#import "KSNullabilityCompat.h"
 
 @class KSPromise;
+
+NS_ASSUME_NONNULL_BEGIN
 
 @interface KSURLConnectionClient : KSNetworkClient <KSNetworkClient>
 @end
 
+NS_ASSUME_NONNULL_END

--- a/Deferred/KSURLSessionClient.h
+++ b/Deferred/KSURLSessionClient.h
@@ -1,6 +1,9 @@
 #import "KSNetworkClient.h"
+#import "KSNullabilityCompat.h"
 
 @class KSPromise;
+
+NS_ASSUME_NONNULL_BEGIN
 
 @interface KSURLSessionClient : NSObject <KSNetworkClient>
 
@@ -11,3 +14,4 @@
 
 @end
 
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Enables better Swift interface generation and better warnings if the
API is being used incorrectly. A compat header is included to not break
Xcode <6.3