### PR TITLE
Nullability Annotations Redux

### DIFF
--- a/Deferred/KSPromise.h
+++ b/Deferred/KSPromise.h
@@ -6,8 +6,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef __nonnull id(^promiseValueCallback)(id value);
-typedef __nonnull id(^promiseErrorCallback)(NSError *error);
+typedef __nullable id(^promiseValueCallback)(__nullable id value);
+typedef __nullable id(^promiseErrorCallback)( NSError * __nullable error);
 typedef void(^deferredCallback)(KSPromise *p);
 
 FOUNDATION_EXPORT NSString *const KSPromiseWhenErrorDomain;


### PR DESCRIPTION
After looking at this more closely, I realized that it's a pretty common usage to return `nil` from callback blocks, so the current annotations are incorrect.

Additionally though, we need to consider the discussion happening on the previous PR (#41) and decide if including the annotations in this file at all is worth the autocomplete regressions.