### PR TITLE
Handle empty arrays passed to [+(KSPromise *)when:(NSArray *)promises]

### DIFF
--- a/Specs/KSDeferredSpec.mm
+++ b/Specs/KSDeferredSpec.mm
@@ -53,6 +53,10 @@ describe(@"KSDeferred", ^{
                 fulfilled should be_truthy;
                 rejected should_not be_truthy;
             });
+
+            it(@"should resolve with an empty array", ^{
+                joinedPromise.value should equal(@[]);
+            });
         });
 
         context(@"when joined promises get resolved or rejected after join", ^{

--- a/Specs/KSDeferredSpec.mm
+++ b/Specs/KSDeferredSpec.mm
@@ -34,6 +34,27 @@ describe(@"KSDeferred", ^{
             promise2 = deferred2.promise;
         });
 
+        context(@"when the array of joined promises is empty", ^{
+            beforeEach(^{
+                joinedPromise = [KSPromise when:@[]];
+
+                fulfilled = rejected = NO;
+
+                [joinedPromise then:^id(id value) {
+                    fulfilled = YES;
+                    return value;
+                } error:^id(NSError *error) {
+                    rejected = YES;
+                    return error;
+                }];
+            });
+
+            it(@"should immediately resolve", ^{
+                fulfilled should be_truthy;
+                rejected should_not be_truthy;
+            });
+        });
+
         context(@"when joined promises get resolved or rejected after join", ^{
             beforeEach(^{
                 joinedPromise = [KSPromise when:[NSArray arrayWithObjects:promise, promise2, nil]];


### PR DESCRIPTION
- Empty arrays passed to the when: method resolve immediately.
- This is in keeping with the Promises/A+ spec and with the way that jQuery and when.js
  handle the when method.