### PR TITLE
Remove conditional from the tvOS declaration in the podspec

### DIFF
--- a/KSDeferred.podspec
+++ b/KSDeferred.podspec
@@ -12,10 +12,7 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = '10.7'
   s.watchos.deployment_target = '2.0'
   s.watchos.exclude_files = "Deferred/KSURLConnectionClient.{h,m}"
-
-  if s.respond_to?(:tvos)
-    s.tvos.deployment_target = '9.0'
-  end
+  s.tvos.deployment_target = '9.0'
 
   s.source_files = 'Deferred', 'Deferred/**/*.{h,m}'
 end


### PR DESCRIPTION
It seems that when Cocoapods Trunk generated the JSON representation of the podspec for the last release, the tvOS platform support didn't get included. Now that tvOS support is included in the public Cocoapods release, the conditional can be removed and a patch release can be cut.