### PR TITLE
Fix a crash when a promise is cancelled within its own callback

### DIFF
--- a/Deferred/KSPromise.m
+++ b/Deferred/KSPromise.m
@@ -216,7 +216,7 @@ NSString *const KSPromiseWhenErrorValuesKey = @"KSPromiseWhenErrorValuesKey";
     if (self.completed || self.cancelled) return;
     self.value = value;
     self.fulfilled = YES;
-    for (KSPromiseCallbacks *callbacks in self.callbacks) {
+    for (__strong KSPromiseCallbacks *callbacks in self.callbacks) {
         id nextValue = self.value;
         if (callbacks.fulfilledCallback) {
             nextValue = callbacks.fulfilledCallback(value);
@@ -234,7 +234,7 @@ NSString *const KSPromiseWhenErrorValuesKey = @"KSPromiseWhenErrorValuesKey";
     if (self.completed || self.cancelled) return;
     self.error = error;
     self.rejected = YES;
-    for (KSPromiseCallbacks *callbacks in self.callbacks) {
+    for (__strong KSPromiseCallbacks *callbacks in self.callbacks) {
         id nextValue = self.error;
         if (callbacks.errorCallback) {
             nextValue = callbacks.errorCallback(error);
@@ -264,7 +264,7 @@ NSString *const KSPromiseWhenErrorValuesKey = @"KSPromiseWhenErrorValuesKey";
 }
 
 - (void)finish {
-    for (KSPromiseCallbacks *callbacks in self.callbacks) {
+    for (__strong KSPromiseCallbacks *callbacks in self.callbacks) {
         if (callbacks.deprecatedCompleteCallback) {
             callbacks.deprecatedCompleteCallback(self);
         }

--- a/Specs/KSPromiseCancellationSpec.mm
+++ b/Specs/KSPromiseCancellationSpec.mm
@@ -102,6 +102,37 @@ describe(@"KSPromiseCancellation", ^{
                 otherDeferredCancelBlockCalled should be_truthy;
             });
         });
+
+        context(@"for a promise that cancels itself within it's finally block", ^{
+            beforeEach(^{
+                deferred = [KSDeferred defer];
+                promise = deferred.promise;
+                [promise finally:^{
+                    [promise cancel];
+                }];
+            });
+
+            context(@"when resolving the deferred", ^{
+                beforeEach(^{
+                    [deferred resolveWithValue:@"some value"];
+                });
+
+                it(@"does not crash and fulfilled the promise", ^{
+                    promise.fulfilled should be_truthy;
+                });
+            });
+
+            context(@"when rejecting the deferred", ^{
+                beforeEach(^{
+                    [deferred rejectWithError:nil];
+                });
+
+                it(@"does not crash and rejects the promise", ^{
+                    promise.rejected should be_truthy;
+                });
+            });
+
+        });
     });
 });
 


### PR DESCRIPTION
NSFastEnumeration doesn't retain objects which is why a crash happens when a
promise is cancelled from within its own callback.

> If a variable is declared in the condition of an Objective-C fast enumeration loop, and the variable has no explicit ownership qualifier, then it is qualified with const __strong and objects encountered during the enumeration are not actually retained.

Source: http://clang.llvm.org/docs/AutomaticReferenceCounting.html#fast-enumeration-iteration-variables