### PR TITLE
Don’t return `nil` from `then`

### DIFF
--- a/Deferred/KSPromise.m
+++ b/Deferred/KSPromise.m
@@ -134,7 +134,6 @@ NSString *const KSPromiseWhenErrorValuesKey = @"KSPromiseWhenErrorValuesKey";
 
 - (KSPromise *)then:(promiseValueCallback)fulfilledCallback
               error:(promiseErrorCallback)errorCallback {
-    if (self.cancelled) return nil;
     if (![self completed]) {
         KSPromiseCallbacks *callbacks = [[KSPromiseCallbacks alloc] initWithFulfilledCallback:fulfilledCallback
                                                                                 errorCallback:errorCallback
@@ -181,7 +180,11 @@ NSString *const KSPromiseWhenErrorValuesKey = @"KSPromiseWhenErrorValuesKey";
 
 - (void)addCancellable:(id<KSCancellable>)cancellable
 {
-    [self.cancellables addObject:cancellable];
+    if (self.cancelled) {
+        [cancellable cancel];
+    } else {
+        [self.cancellables addObject:cancellable];
+    }
 }
 
 - (void)cancel {

--- a/Specs/KSPromiseCancellationSpec.mm
+++ b/Specs/KSPromiseCancellationSpec.mm
@@ -58,6 +58,38 @@ describe(@"KSPromiseCancellation", ^{
                 [deferred rejectWithError:rejectError];
                 errorBlockCalledWithError should be_nil;
             });
+
+            context(@"when chaining a promise to a cancelled promise", ^{
+                __block BOOL thenBlockCalled;
+                __block KSPromise *childPromiseOfCancelledPromise;
+                beforeEach(^{
+                    thenBlockCalled = NO;
+                    childPromiseOfCancelledPromise = [promise then:^id(id value) {
+                        thenBlockCalled = YES;
+                        return value;
+                    }];
+                });
+
+                it(@"did not return nil", ^{
+                    childPromiseOfCancelledPromise should_not be_nil;
+                });
+
+                it(@"does not call the then block", ^{
+                    thenBlockCalled should be_falsy;
+                });
+            });
+
+            context(@"when adding a cancellable to the cancelled promise", ^{
+                __block id<KSCancellable> cancellable;
+                beforeEach(^{
+                    cancellable = nice_fake_for(@protocol(KSCancellable));
+                    [promise addCancellable:cancellable];
+                });
+
+                it(@"instantly cancels the cancellable", ^{
+                    cancellable should have_received(@selector(cancel));
+                });
+            });
         });
 
         context(@"for a child promise", ^{


### PR DESCRIPTION
The header of `KSPromise` defines `then:` and `then:error:`
to return a `nonnull` value but the implementation can return
`nil` when calling one of these methods on a cancelled promise.
This especially is problematic for interoperability with Swift since
it relies on the nullability annotations.

This changes the behavior so that chaining a promise to a
cancelled promise instantly cancels the returned promise
turning it basically into a noop.